### PR TITLE
Fix extract_aliases() to ignore view names in CREATE VIEW.

### DIFF
--- a/task.py
+++ b/task.py
@@ -12,7 +12,6 @@ from tune.protox.cli import protox_group
 # TODO(phw2): remove write permissions on old run_*/ dirs to enforce that they are immutable
 
 
-
 task_logger = logging.getLogger("task")
 task_logger.setLevel(logging.INFO)
 

--- a/tune/protox/env/workload_utils.py
+++ b/tune/protox/env/workload_utils.py
@@ -201,10 +201,9 @@ def extract_aliases(stmts):
                 elif isinstance(node, pglast.ast.RangeVar):
                     ft = node
                     relname = ft.relname
-                    # TODO(phw2): convert to pglast v6
-                    # if stmt.stmt["node_tag"] == "ViewStmt":
-                    #     if node == stmt.stmt.view:
-                    #         continue
+                    if isinstance(stmt.stmt, pglast.ast.ViewStmt):
+                        if node == stmt.stmt.view:
+                            continue
 
                     alias = (
                         ft.relname


### PR DESCRIPTION
This PR modifies extract_aliases() to ignore the names of views that only appear in a CREATE VIEW statement.

These semantics were part of the old extract_aliases() function back when we were using pglast 3.8.
When we migrated to pglast 6.2, we fixed all errors from the version change except for the one in this PR.
Thus, this PR completes the migration.
Fix #8.

---

**Summary:** extract_aliases() now ignores the names of views if they only appear in a CREATE VIEW statement and do not appear anywhere else in the query.

**Demo:**
Added two unit tests to verify this behavior.

<img width="1056" alt="Screenshot 2024-03-03 at 21 46 10" src="https://github.com/cmu-db/dbgym/assets/20631215/e8b8e90c-a305-463b-9d92-1ac388118d25">


**Details:**
* These semantics were a part of the old extract_aliases() function back when we were using pglast==3.8. When we migrated to pglast==6.2 earlier, we fixed all errors from the version change except the one in this PR. Thus, this PR completes the migration.
