### PR TITLE
Remove weak_bias check when selecting the best embedding.

### DIFF
--- a/tune/protox/embedding/select.py
+++ b/tune/protox/embedding/select.py
@@ -116,9 +116,6 @@ def _load_data(cfg, select_args):
                 if info["latent_dim"] != select_args.latent_dim:
                     continue
 
-            if not info["weak_bias"]:
-                continue
-
             output_scale = config["metric_loss_md"]["output_scale"]
             bias_sep = config["metric_loss_md"]["bias_separation"]
 


### PR DESCRIPTION
This PR removes the weak_bias check when selecting the best embedding.

Previously, this check would occasionally filter out all candidates, resulting in a crash.
There should be minimal downside to removing this check; doing so only increases the number of candidates.

Fix #6.