### PR TITLE
Modify embedding workload input format.

### DIFF
--- a/tune/protox/embedding/analyze.py
+++ b/tune/protox/embedding/analyze.py
@@ -90,7 +90,7 @@ def _create_stats_for_part(cfg, part_dpath, generic_args, analyze_args):
     with open_and_save(cfg, generic_args.benchmark_config_path, "r") as f:
         data = yaml.safe_load(f)
         max_attrs, max_cat_features, _, _ = fetch_index_parameters(
-            cfg, generic_args.benchmark, data
+            cfg, generic_args.benchmark, data, generic_args.workload_folder_path
         )
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
@@ -310,7 +310,7 @@ def _create_ranges_for_embedder(cfg, embedder_fpath, generic_args, analyze_args)
         data = yaml.safe_load(f)
         tables = data["protox"]["tables"]
         max_attrs, max_cat_features, att_usage, _ = fetch_index_parameters(
-            cfg, generic_args.benchmark, data
+            cfg, generic_args.benchmark, data, generic_args.workload_folder_path
         )
 
     # don't use open_and_save() because we generated embeddings_config_fpath in this run

--- a/tune/protox/embedding/train.py
+++ b/tune/protox/embedding/train.py
@@ -29,6 +29,7 @@ from tune.protox.embedding.train_all import train_all_embeddings
 
 # generic args
 @click.argument("benchmark")
+@click.argument("workload-name")
 @click.option(
     "--benchmark-config-path",
     default=None,
@@ -134,6 +135,7 @@ from tune.protox.embedding.train_all import train_all_embeddings
 def train(
     ctx,
     benchmark,
+    workload_name,
     benchmark_config_path,
     dataset_path,
     seed,
@@ -178,9 +180,12 @@ def train(
     torch.manual_seed(seed)
     logging.getLogger().setLevel(logging.INFO)
 
+    workload_folder_path = (
+        ctx.obj.dbgym_data_path / "benchmark" / benchmark / "workloads" / workload_name
+    )
     # group args. see comment in datagen.py:datagen()
     generic_args = EmbeddingTrainGenericArgs(
-        benchmark, benchmark_config_path, dataset_path, seed
+        benchmark, benchmark_config_path, dataset_path, seed, workload_folder_path
     )
     train_args = EmbeddingTrainAllArgs(
         hpo_space_path,
@@ -212,11 +217,14 @@ def train(
 class EmbeddingTrainGenericArgs:
     """Same comment as EmbeddingDatagenGenericArgs"""
 
-    def __init__(self, benchmark, benchmark_config_path, dataset_path, seed):
+    def __init__(
+        self, benchmark, benchmark_config_path, dataset_path, seed, workload_folder_path
+    ):
         self.benchmark = benchmark
         self.benchmark_config_path = benchmark_config_path
         self.dataset_path = dataset_path
         self.seed = seed
+        self.workload_folder_path = workload_folder_path
 
 
 class EmbeddingTrainAllArgs:

--- a/tune/protox/embedding/train_all.py
+++ b/tune/protox/embedding/train_all.py
@@ -157,6 +157,7 @@ def _hpo_train(config, cfg, generic_args, train_args):
         trial_dir,
         generic_args.benchmark_config_path,
         train_args.train_size,
+        generic_args.workload_folder_path,
         dataloader_num_workers=0,
         disable_tqdm=True,
     )
@@ -188,6 +189,7 @@ def _build_trainer(
     trial_dir,
     benchmark_config_path,
     train_size,
+    workload_folder_path,
     dataloader_num_workers=0,
     disable_tqdm=False,
 ):
@@ -198,7 +200,7 @@ def _build_trainer(
     with open_and_save(cfg, benchmark_config_path, "r") as f:
         data = yaml.safe_load(f)
         max_attrs, max_cat_features, _, class_mapping = fetch_index_parameters(
-            cfg, benchmark, data
+            cfg, benchmark, data, workload_folder_path
         )
 
     config["class_mapping"] = {}

--- a/tune/protox/embedding/utils.py
+++ b/tune/protox/embedding/utils.py
@@ -63,22 +63,14 @@ def parse_hyperopt_config(config):
     return parsed_config
 
 
-def fetch_index_parameters(cfg, benchmark, data):
+def fetch_index_parameters(cfg, benchmark, data, workload_folder_path):
     tables = data["protox"]["tables"]
     attributes = data["protox"]["attributes"]
     query_spec = data["protox"]["query_spec"]
 
-    # TODO(phw2): figure out how to pass query_directory. should it in the .yaml or should it be a CLI args?
-    if "query_directory" not in query_spec:
-        assert "query_order" not in query_spec
-        query_spec["query_directory"] = os.path.join(
-            cfg.dbgym_data_path, f"{benchmark}_queries"
-        )
-        query_spec["query_order"] = os.path.join(
-            query_spec["query_directory"], f"order.txt"
-        )
-
-    workload = Workload(cfg, tables, attributes, query_spec, pid=None)
+    workload = Workload(
+        cfg, tables, attributes, query_spec, workload_folder_path, pid=None
+    )
     att_usage = workload.process_column_usage()
 
     space = IndexSpace(


### PR DESCRIPTION
This PR modifies how the embedding takes in a workload as input.

Instead of specifying query_directory or query_order in the benchmark's YAML, we pass in workload-name as a CLI argument.

Assuming that the gym is generating the workload, (benchmark, workload-name) is enough to identify the workload's folder and its corresponding order.txt. The format of order.txt is currently:
QueryId,AbsPathToQuerySQL[,Weight]