### PR TITLE
Query execution interface

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,6 @@
 name: Static, Unit, Integration, and End-to-End Tests
 
 on:
-  push: {}
   pull_request:
     branches: [main]
 

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -45,7 +45,15 @@ class PostgresConnTests(unittest.TestCase):
             IntegtestWorkspace.get_dbgym_cfg().dbgym_workspace_path
         )
 
+        # The reason we restart Postgres every time is to ensure a "clean" starting point
+        # so that all tests are independent of each other.
+        self.pg_conn = self.create_pg_conn()
+        self.pg_conn.restore_pristine_snapshot()
+        self.pg_conn.restart_postgres()
+        self.assertTrue(get_is_postgres_running())
+
     def tearDown(self) -> None:
+        self.pg_conn.shutdown_postgres()
         self.assertFalse(get_is_postgres_running())
 
     def create_pg_conn(self, pgport: int = DEFAULT_POSTGRES_PORT) -> PostgresConn:
@@ -59,21 +67,11 @@ class PostgresConnTests(unittest.TestCase):
             DEFAULT_BOOT_CONFIG_FPATH,
         )
 
-    def test_init(self) -> None:
-        _ = self.create_pg_conn()
-
-    def test_start_and_stop(self) -> None:
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-        self.assertTrue(get_is_postgres_running())
-        pg_conn.shutdown_postgres()
-
     def test_start_on_multiple_ports(self) -> None:
-        pg_conn0 = self.create_pg_conn()
-        pg_conn0.restore_pristine_snapshot()
-        pg_conn0.restart_postgres()
+        # The setUp() function should have started Postgres on DEFAULT_POSTGRES_PORT.
         self.assertEqual(set(get_running_postgres_ports()), {DEFAULT_POSTGRES_PORT})
+
+        # Now, we start Postgres on a new port.
         pg_conn1 = self.create_pg_conn(DEFAULT_POSTGRES_PORT + 1)
         pg_conn1.restore_pristine_snapshot()
         pg_conn1.restart_postgres()
@@ -83,117 +81,66 @@ class PostgresConnTests(unittest.TestCase):
         )
 
         # Clean up
-        pg_conn0.shutdown_postgres()
         pg_conn1.shutdown_postgres()
 
     def test_connect_and_disconnect(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Test
-        self.assertIsNone(pg_conn._conn)
-        conn = pg_conn.conn()
+        self.assertIsNone(self.pg_conn._conn)
+        conn = self.pg_conn.conn()
         self.assertIsNotNone(conn)
         self.assertIs(
-            conn, pg_conn._conn
+            conn, self.pg_conn._conn
         )  # The conn should be cached so these objects should be the same
-        self.assertIs(conn, pg_conn.conn())  # Same thing here
-        pg_conn.disconnect()
-        self.assertIsNone(pg_conn._conn)
-
-        # Cleanup
-        pg_conn.shutdown_postgres()
+        self.assertIs(conn, self.pg_conn.conn())  # Same thing here
+        self.pg_conn.disconnect()
+        self.assertIsNone(self.pg_conn._conn)
 
     def test_start_with_changes(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Test
-        initial_sysknobs = pg_conn.get_system_knobs()
+        initial_sysknobs = self.pg_conn.get_system_knobs()
 
         # First call
         self.assertEqual(initial_sysknobs["wal_buffers"], "4MB")
-        pg_conn.restart_with_changes({"wal_buffers": "8MB"})
-        new_sysknobs = pg_conn.get_system_knobs()
+        self.pg_conn.restart_with_changes({"wal_buffers": "8MB"})
+        new_sysknobs = self.pg_conn.get_system_knobs()
         self.assertEqual(new_sysknobs["wal_buffers"], "8MB")
 
         # Second call
         self.assertEqual(initial_sysknobs["enable_nestloop"], "on")
-        pg_conn.restart_with_changes({"enable_nestloop": "off"})
-        new_sysknobs = pg_conn.get_system_knobs()
+        self.pg_conn.restart_with_changes({"enable_nestloop": "off"})
+        new_sysknobs = self.pg_conn.get_system_knobs()
         self.assertEqual(new_sysknobs["enable_nestloop"], "off")
         # The changes should not be additive. The "wal_buffers" should have "reset" to 4MB.
         self.assertEqual(new_sysknobs["wal_buffers"], "4MB")
 
-        # Cleanup
-        pg_conn.shutdown_postgres()
-
     def test_start_with_changes_doesnt_modify_input(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Test
         conf_changes = {"wal_buffers": "8MB"}
         orig_conf_changes = copy.deepcopy(conf_changes)
-        pg_conn.restart_with_changes(conf_changes)
+        self.pg_conn.restart_with_changes(conf_changes)
         self.assertEqual(conf_changes, orig_conf_changes)
 
-        # Cleanup
-        pg_conn.shutdown_postgres()
-
     def test_time_query(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Testing no explain no timeout.
-        runtime, did_time_out, explain_data = pg_conn.time_query("select pg_sleep(1)")
+        runtime, did_time_out, explain_data = self.pg_conn.time_query(
+            "select pg_sleep(1)"
+        )
         # The runtime should be about 1 second.
         self.assertTrue(abs(runtime - 1_000_000) < 100_000)
         self.assertFalse(did_time_out)
         self.assertIsNone(explain_data)
 
-        # Cleanup
-        pg_conn.shutdown_postgres()
-
     def test_time_query_with_explain(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Testing with explain.
-        runtime, did_time_out, explain_data = pg_conn.time_query(
+        runtime, did_time_out, explain_data = self.pg_conn.time_query(
             "select pg_sleep(1)", add_explain=True
         )
         self.assertTrue(abs(runtime - 1_000_000) < 100_000)
         self.assertFalse(did_time_out)
         self.assertIsNotNone(explain_data)
 
-        # Cleanup
-        pg_conn.shutdown_postgres()
-
     def test_time_query_with_timeout(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Testing with timeout.
-        runtime, did_time_out, _ = pg_conn.time_query("select pg_sleep(3)", timeout=2)
+        runtime, did_time_out, _ = self.pg_conn.time_query(
+            "select pg_sleep(3)", timeout=2
+        )
         # The runtime should be about what the timeout is.
         self.assertTrue(abs(runtime - 2_000_000) < 100_000)
         self.assertTrue(did_time_out)
-
-        # Cleanup
-        pg_conn.shutdown_postgres()
 
 
 if __name__ == "__main__":

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -153,13 +153,21 @@ class PostgresConnTests(unittest.TestCase):
         pg_conn.restore_pristine_snapshot()
         pg_conn.restart_postgres()
 
-        # Test
         # Testing no explain no timeout.
         runtime, did_time_out, explain_data = pg_conn.time_query("select pg_sleep(1)")
         # The runtime should be about 1 second.
         self.assertTrue(abs(runtime - 1_000_000) < 100_000)
         self.assertFalse(did_time_out)
         self.assertIsNone(explain_data)
+
+        # Cleanup
+        pg_conn.shutdown_postgres()
+
+    def test_time_query_with_explain(self) -> None:
+        # Setup
+        pg_conn = self.create_pg_conn()
+        pg_conn.restore_pristine_snapshot()
+        pg_conn.restart_postgres()
 
         # Testing with explain.
         runtime, did_time_out, explain_data = pg_conn.time_query(
@@ -168,6 +176,15 @@ class PostgresConnTests(unittest.TestCase):
         self.assertTrue(abs(runtime - 1_000_000) < 100_000)
         self.assertFalse(did_time_out)
         self.assertIsNotNone(explain_data)
+
+        # Cleanup
+        pg_conn.shutdown_postgres()
+
+    def test_time_query_with_timeout(self) -> None:
+        # Setup
+        pg_conn = self.create_pg_conn()
+        pg_conn.restore_pristine_snapshot()
+        pg_conn.restart_postgres()
 
         # Testing with timeout.
         runtime, did_time_out, _ = pg_conn.time_query("select pg_sleep(3)", timeout=2)

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -190,14 +190,14 @@ class PostgresConnTests(unittest.TestCase):
 
         # Testing with explain.
         runtime, did_time_out, explain_data = pg_conn.time_query(
-            "explain (analyze, format json, timing off) select pg_sleep(1)"
+            "select pg_sleep(1)", add_explain=True
         )
         self.assertTrue(abs(runtime - 1_000_000) < 100_000)
         self.assertFalse(did_time_out)
         self.assertIsNotNone(explain_data)
 
         # Testing with timeout.
-        runtime, did_time_out, _ = pg_conn.time_query("select pg_sleep(3)", 2)
+        runtime, did_time_out, _ = pg_conn.time_query("select pg_sleep(3)", timeout=2)
         # The runtime should be about what the timeout is.
         self.assertTrue(abs(runtime - 2_000_000) < 100_000)
         self.assertTrue(did_time_out)

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -125,22 +125,6 @@ class PostgresConnTests(unittest.TestCase):
 
         # Test
         initial_sysknobs = pg_conn.get_system_knobs()
-        self.assertEqual(initial_sysknobs["wal_buffers"], "4MB")
-        pg_conn.restart_with_changes({"wal_buffers": "8MB"})
-        new_sysknobs = pg_conn.get_system_knobs()
-        self.assertEqual(new_sysknobs["wal_buffers"], "8MB")
-
-        # Cleanup
-        pg_conn.shutdown_postgres()
-
-    def test_multiple_start_with_changes(self) -> None:
-        # Setup
-        pg_conn = self.create_pg_conn()
-        pg_conn.restore_pristine_snapshot()
-        pg_conn.restart_postgres()
-
-        # Test
-        initial_sysknobs = pg_conn.get_system_knobs()
 
         # First call
         self.assertEqual(initial_sysknobs["wal_buffers"], "4MB")

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -173,6 +173,22 @@ class PostgresConnTests(unittest.TestCase):
         # Cleanup
         pg_conn.shutdown_postgres()
 
+    def test_time_query(self) -> None:
+        # Setup
+        pg_conn = self.create_pg_conn()
+        pg_conn.restore_pristine_snapshot()
+        pg_conn.restart_postgres()
+
+        # Test
+        runtime, did_time_out, explain_data = pg_conn.time_query("select 1", 5)
+        # The runtime (in microseconds) should be within these two orders of magnitude.
+        self.assertTrue(100 <= runtime < 10000)
+        self.assertFalse(did_time_out)
+        self.assertIsNone(explain_data)
+
+        # Cleanup
+        pg_conn.shutdown_postgres()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/env/integtest_pg_conn.py
+++ b/env/integtest_pg_conn.py
@@ -7,7 +7,11 @@ import yaml
 from psycopg.errors import QueryCanceled
 
 from env.pg_conn import PostgresConn
-from util.pg import DEFAULT_POSTGRES_PORT, get_is_postgres_running, get_running_postgres_ports
+from util.pg import (
+    DEFAULT_POSTGRES_PORT,
+    get_is_postgres_running,
+    get_running_postgres_ports,
+)
 from util.workspace import (
     DEFAULT_BOOT_CONFIG_FPATH,
     DBGymConfig,

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -100,8 +100,13 @@ class PostgresConn:
             self.log_step += 1
 
     def time_query(
-        self, prefix: str, query: str, timeout: float
+        self, query: str, timeout: float
     ) -> tuple[float, bool, Any]:
+        """
+        Run a query with a timeout. If you want to attach per-query knobs, attach them to the query string itself.
+
+        It returns the runtime, whether the query timed out, and the explain data.
+        """
         did_time_out = False
         has_explain = "EXPLAIN" in query
         explain_data = None
@@ -118,12 +123,12 @@ class PostgresConn:
                 explain_data = c
 
             logging.getLogger(DBGYM_LOGGER_NAME).debug(
-                f"{prefix} evaluated in {qid_runtime/1e6}"
+                f"{query} evaluated in {qid_runtime/1e6}"
             )
 
         except QueryCanceled:
             logging.getLogger(DBGYM_LOGGER_NAME).debug(
-                f"{prefix} exceeded evaluation timeout {timeout}"
+                f"{query} exceeded evaluation timeout {timeout}"
             )
             qid_runtime = timeout * 1e6
             did_time_out = True

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -179,7 +179,7 @@ class PostgresConn:
             qid_runtime = timeout * 1e6
             did_time_out = True
         except Exception as e:
-            assert False, e
+            raise e
         finally:
             # Wipe the statement timeout.
             self.force_statement_timeout(0)

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -109,7 +109,9 @@ class PostgresConn:
             except QueryCanceled:
                 retry = True
 
-    def time_query(self, query: str, timeout_sec: float = 0) -> tuple[float, bool, Any]:
+    def time_query(
+        self, query: str, timeout_sec: float = 0
+    ) -> tuple[float, bool, Optional[dict[str, Any]]]:
         """
         Run a query with a timeout. If you want to attach per-query knobs, attach them to the query string itself.
         Following Postgres's convention, timeout=0 indicates "disable timeout"

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -137,7 +137,7 @@ class PostgresConn:
         did_time_out = False
         explain_data = None
 
-        def hint_notice_handler(notice):
+        def hint_notice_handler(notice) -> None:
             """
             Custom handler for database notices.
             Raises an error or logs the notice if it indicates a problem.

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -137,6 +137,17 @@ class PostgresConn:
         did_time_out = False
         explain_data = None
 
+        def hint_notice_handler(notice):
+            """
+            Custom handler for database notices.
+            Raises an error or logs the notice if it indicates a problem.
+            """
+            logging.getLogger(DBGYM_LOGGER_NAME).warning(f"Postgres notice: {notice}")
+            if "hint" in notice.message.lower():
+                raise RuntimeError(f"Query hint failed: {notice.message}")
+
+        self.conn().add_notice_handler(hint_notice_handler)
+
         try:
             if query_knobs:
                 query = f"/*+ {' '.join(query_knobs)} */ {query}"

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -137,16 +137,16 @@ class PostgresConn:
         did_time_out = False
         explain_data = None
 
-        def hint_notice_handler(notice) -> None:
-            """
-            Custom handler for database notices.
-            Raises an error or logs the notice if it indicates a problem.
-            """
-            logging.getLogger(DBGYM_LOGGER_NAME).warning(f"Postgres notice: {notice}")
-            if "hint" in notice.message.lower():
-                raise RuntimeError(f"Query hint failed: {notice.message}")
+        # def hint_notice_handler(notice) -> None:
+        #     """
+        #     Custom handler for database notices.
+        #     Raises an error or logs the notice if it indicates a problem.
+        #     """
+        #     logging.getLogger(DBGYM_LOGGER_NAME).warning(f"Postgres notice: {notice}")
+        #     if "hint" in notice.message.lower():
+        #         raise RuntimeError(f"Query hint failed: {notice.message}")
 
-        self.conn().add_notice_handler(hint_notice_handler)
+        # self.conn().add_notice_handler(hint_notice_handler)
 
         try:
             if query_knobs:

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -106,7 +106,7 @@ class PostgresConn:
         It returns the runtime, whether the query timed out, and the explain data.
         """
         did_time_out = False
-        has_explain = "EXPLAIN" in query
+        has_explain = "explain" in query.lower()
         explain_data = None
 
         try:

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -99,9 +99,7 @@ class PostgresConn:
             shutil.move(pglog_fpath, pglog_this_step_fpath)
             self.log_step += 1
 
-    def time_query(
-        self, query: str, timeout: float
-    ) -> tuple[float, bool, Any]:
+    def time_query(self, query: str, timeout: float) -> tuple[float, bool, Any]:
         """
         Run a query with a timeout. If you want to attach per-query knobs, attach them to the query string itself.
 

--- a/env/pg_conn.py
+++ b/env/pg_conn.py
@@ -116,7 +116,8 @@ class PostgresConn:
         Run a query with a timeout (in seconds). If you want to attach per-query knobs, attach them to the query string
         itself. Following Postgres's convention, timeout=0 indicates "disable timeout"
 
-        It returns the runtime, whether the query timed out, and the explain data if add_explain is True.
+        It returns the runtime, whether the query timed out, and the explain data if add_explain is True. Note that if
+        the query timed out, it won't have any explain data and thus explain_data will be None.
 
         If you write explain in the query manually instead of setting add_explain, it won't return explain_data. This
         is because it won't know the format of the explain data.

--- a/scripts/pat_test.sh
+++ b/scripts/pat_test.sh
@@ -5,9 +5,7 @@ set -euxo pipefail
 . ./experiments/load_per_machine_envvars.sh
 
 # space for testing. uncomment this to run individual commands from the script (copy pasting is harder because there are envvars)
-python3 task.py tune protox agent hpo job --workload-name-suffix demo --num-samples 2 --max-concurrent 2 --workload-timeout 15 --query-timeout 2 --tune-duration-during-hpo 0.03  --intended-dbdata-hardware $INTENDED_DBDATA_HARDWARE --dbdata-parent-dpath $DBDATA_PARENT_DPATH --build-space-good-for-boot
 python3 task.py tune protox agent tune job --workload-name-suffix demo
-python3 task.py tune protox agent replay job --workload-name-suffix demo
 exit 0
 
 # benchmark

--- a/tune/protox/env/types.py
+++ b/tune/protox/env/types.py
@@ -137,7 +137,7 @@ BestQueryRun = NamedTuple(
         ("query_run", Optional[QueryRun]),
         ("runtime", Optional[float]),
         ("timed_out", bool),
-        ("explain_data", Optional[Any]),
+        ("explain_data", Optional[dict[str, Any]]),
         ("metric_data", Optional[dict[str, Any]]),
     ],
 )

--- a/tune/protox/env/util/execute.py
+++ b/tune/protox/env/util/execute.py
@@ -34,7 +34,6 @@ def _force_statement_timeout(
 
 
 def _acquire_metrics_around_query(
-    prefix: str,
     pg_conn: PostgresConn,
     query: str,
     query_timeout: float = 0.0,
@@ -52,7 +51,7 @@ def _acquire_metrics_around_query(
         ), f'Setting query_timeout to 0 indicates "timeout". However, setting query_timeout ({query_timeout}) < 0 is a bug.'
 
     qid_runtime, did_time_out, explain_data = pg_conn.time_query(
-        prefix, query, query_timeout
+        query, query_timeout
     )
 
     # Wipe the statement timeout.
@@ -108,7 +107,6 @@ def execute_variations(
         )
 
         runtime, did_time_out, explain_data, metric = _acquire_metrics_around_query(
-            prefix=qr.prefix_qid,
             pg_conn=pg_conn,
             query=pqk_query,
             query_timeout=timeout_limit,

--- a/tune/protox/env/util/execute.py
+++ b/tune/protox/env/util/execute.py
@@ -50,9 +50,7 @@ def _acquire_metrics_around_query(
             query_timeout == 0
         ), f'Setting query_timeout to 0 indicates "timeout". However, setting query_timeout ({query_timeout}) < 0 is a bug.'
 
-    qid_runtime, did_time_out, explain_data = pg_conn.time_query(
-        query, query_timeout
-    )
+    qid_runtime, did_time_out, explain_data = pg_conn.time_query(query, query_timeout)
 
     # Wipe the statement timeout.
     _force_statement_timeout(pg_conn.conn(), 0)

--- a/tune/protox/env/util/execute.py
+++ b/tune/protox/env/util/execute.py
@@ -33,7 +33,6 @@ def _force_statement_timeout(
 
 
 def _time_query(
-    artifact_manager: Optional[ArtifactManager],
     prefix: str,
     connection: psycopg.Connection[Any],
     query: str,
@@ -90,7 +89,7 @@ def _acquire_metrics_around_query(
         ), f'Setting query_timeout to 0 indicates "timeout". However, setting query_timeout ({query_timeout}) < 0 is a bug.'
 
     qid_runtime, did_time_out, explain_data = _time_query(
-        artifact_manager, prefix, connection, query, query_timeout
+        prefix, connection, query, query_timeout
     )
 
     # Wipe the statement timeout.

--- a/tune/protox/env/util/execute.py
+++ b/tune/protox/env/util/execute.py
@@ -26,7 +26,7 @@ def _acquire_metrics_around_query(
     query: str,
     query_timeout: float = 0.0,
     observation_space: Optional[StateSpace] = None,
-) -> tuple[float, bool, dict[str, Any], Any]:
+) -> tuple[float, bool, Optional[dict[str, Any]], Any]:
     pg_conn.force_statement_timeout(0)
     if observation_space and observation_space.require_metrics():
         initial_metrics = observation_space.construct_online(pg_conn.conn())
@@ -34,7 +34,6 @@ def _acquire_metrics_around_query(
     qid_runtime, did_time_out, explain_data = pg_conn.time_query(
         query, add_explain=True, timeout=query_timeout
     )
-    assert explain_data is not None
 
     if observation_space and observation_space.require_metrics():
         final_metrics = observation_space.construct_online(pg_conn.conn())

--- a/tune/protox/env/util/execute.py
+++ b/tune/protox/env/util/execute.py
@@ -7,6 +7,7 @@ import psycopg
 from psycopg import Connection
 from psycopg.errors import QueryCanceled
 
+from env.pg_conn import PostgresConn
 from tune.protox.env.artifact_manager import ArtifactManager
 from tune.protox.env.space.primitive.knob import CategoricalKnob, Knob
 from tune.protox.env.space.state.space import StateSpace
@@ -32,70 +33,32 @@ def _force_statement_timeout(
             retry = True
 
 
-def _time_query(
-    prefix: str,
-    connection: psycopg.Connection[Any],
-    query: str,
-    timeout: float,
-) -> tuple[float, bool, Any]:
-    did_time_out = False
-    has_explain = "EXPLAIN" in query
-    explain_data = None
-
-    try:
-        start_time = time.time()
-        cursor = connection.execute(query)
-        qid_runtime = (time.time() - start_time) * 1e6
-
-        if has_explain:
-            c = [c for c in cursor][0][0][0]
-            assert "Execution Time" in c
-            qid_runtime = float(c["Execution Time"]) * 1e3
-            explain_data = c
-
-        logging.getLogger(DBGYM_LOGGER_NAME).debug(
-            f"{prefix} evaluated in {qid_runtime/1e6}"
-        )
-
-    except QueryCanceled:
-        logging.getLogger(DBGYM_LOGGER_NAME).debug(
-            f"{prefix} exceeded evaluation timeout {timeout}"
-        )
-        qid_runtime = timeout * 1e6
-        did_time_out = True
-    except Exception as e:
-        assert False, e
-    # qid_runtime is in microseconds.
-    return qid_runtime, did_time_out, explain_data
-
-
 def _acquire_metrics_around_query(
-    artifact_manager: Optional[ArtifactManager],
     prefix: str,
-    connection: psycopg.Connection[Any],
+    pg_conn: PostgresConn,
     query: str,
     query_timeout: float = 0.0,
     observation_space: Optional[StateSpace] = None,
 ) -> tuple[float, bool, Any, Any]:
-    _force_statement_timeout(connection, 0)
+    _force_statement_timeout(pg_conn.conn(), 0)
     if observation_space and observation_space.require_metrics():
-        initial_metrics = observation_space.construct_online(connection)
+        initial_metrics = observation_space.construct_online(pg_conn.conn())
 
     if query_timeout > 0:
-        _force_statement_timeout(connection, query_timeout * 1000)
+        _force_statement_timeout(pg_conn.conn(), query_timeout * 1000)
     else:
         assert (
             query_timeout == 0
         ), f'Setting query_timeout to 0 indicates "timeout". However, setting query_timeout ({query_timeout}) < 0 is a bug.'
 
-    qid_runtime, did_time_out, explain_data = _time_query(
-        prefix, connection, query, query_timeout
+    qid_runtime, did_time_out, explain_data = pg_conn.time_query(
+        prefix, query, query_timeout
     )
 
     # Wipe the statement timeout.
-    _force_statement_timeout(connection, 0)
+    _force_statement_timeout(pg_conn.conn(), 0)
     if observation_space and observation_space.require_metrics():
-        final_metrics = observation_space.construct_online(connection)
+        final_metrics = observation_space.construct_online(pg_conn.conn())
         diff = observation_space.state_delta(initial_metrics, final_metrics)
     else:
         diff = None
@@ -105,7 +68,7 @@ def _acquire_metrics_around_query(
 
 
 def execute_variations(
-    connection: psycopg.Connection[Any],
+    pg_conn: PostgresConn,
     runs: list[QueryRun],
     query: str,
     query_timeout: float = 0,
@@ -145,9 +108,8 @@ def execute_variations(
         )
 
         runtime, did_time_out, explain_data, metric = _acquire_metrics_around_query(
-            artifact_manager=artifact_manager,
             prefix=qr.prefix_qid,
-            connection=connection,
+            pg_conn=pg_conn,
             query=pqk_query,
             query_timeout=timeout_limit,
             observation_space=observation_space,

--- a/tune/protox/env/workload.py
+++ b/tune/protox/env/workload.py
@@ -34,7 +34,6 @@ from tune.protox.env.types import (
     TableColTuple,
 )
 from tune.protox.env.util.execute import (
-    _acquire_metrics_around_query,
     execute_variations,
 )
 from tune.protox.env.util.reward import RewardUtility

--- a/tune/protox/env/workload.py
+++ b/tune/protox/env/workload.py
@@ -33,9 +33,7 @@ from tune.protox.env.types import (
     TableAttrSetMap,
     TableColTuple,
 )
-from tune.protox.env.util.execute import (
-    execute_variations,
-)
+from tune.protox.env.util.execute import execute_variations
 from tune.protox.env.util.reward import RewardUtility
 from tune.protox.env.util.workload_analysis import (
     extract_aliases,
@@ -475,7 +473,7 @@ class Workload(object):
 
                 if not skip_execute:
                     best_run: BestQueryRun = execute_variations(
-                        connection=pg_conn.conn(),
+                        pg_conn=pg_conn,
                         runs=runs,
                         query=query,
                         query_timeout=min(


### PR DESCRIPTION
**Summary**: Added query execution interface in `env/`.

**Demo**:
A passing unit test.
<img width="1092" alt="Screenshot 2024-12-21 at 12 38 33" src="https://github.com/user-attachments/assets/1556d975-f5d3-4a2e-b571-00288fa2f355" />

**Details**:
* The specific interface is the `time_query()` function in `PostgresConn`.
* I chose to have a **per-query interface** instead of a per-workload interface because different agents might have different ways of executing the queries of an OLAP workload. For example, Proto-X executes multiple "variations" of each query when executing a workload. A future agent might also only execute a subset of queries in a workload.
* The interface allows you to specify per-query knobs and a timeout. It returns the **runtime but not the results** of the query. The reason it does not return the results is so that it's **compatible with Boot** (which estimates the runtime but not the results).