### PR TITLE
Standardized logic around fully resolved paths

### DIFF
--- a/benchmark/job/cli.py
+++ b/benchmark/job/cli.py
@@ -10,6 +10,7 @@ from util.workspace import (
     DBGymConfig,
     default_tables_dname,
     get_workload_name,
+    is_fully_resolved,
     link_result,
 )
 
@@ -260,10 +261,8 @@ def _generate_job_workload(
                 dbgym_cfg.cur_symlinks_data_path(mkdir=True)
                 / (f"{JOB_QUERIES_DNAME}.link")
             ).resolve() / f"{qname}.sql"
-            assert (
-                sql_fpath.exists()
-                and not sql_fpath.is_symlink()
-                and sql_fpath.is_absolute()
+            assert is_fully_resolved(
+                sql_fpath
             ), "We should only write existent real absolute paths to a file"
             f.write(f"Q{qname},{sql_fpath}\n")
 

--- a/benchmark/job/load_info.py
+++ b/benchmark/job/load_info.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from benchmark.constants import DEFAULT_SCALE_FACTOR
 from dbms.load_info_base_class import LoadInfoBaseClass
-from util.workspace import DBGymConfig, default_tables_dname
+from util.workspace import DBGymConfig, default_tables_dname, is_fully_resolved
 
 JOB_SCHEMA_FNAME = "job_schema.sql"
 
@@ -55,10 +55,8 @@ class JobLoadInfo(LoadInfoBaseClass):
             data_root_dpath / f"{default_tables_dname(DEFAULT_SCALE_FACTOR)}.link"
         )
         tables_dpath = tables_symlink_dpath.resolve()
-        assert (
-            tables_dpath.exists()
-            and tables_dpath.is_absolute()
-            and not tables_dpath.is_symlink()
+        assert is_fully_resolved(
+            tables_dpath
         ), f"tables_dpath ({tables_dpath}) should be an existent real absolute path. Make sure you have generated the TPC-H data"
         self._tables_and_fpaths = []
         for table in JobLoadInfo.TABLES:

--- a/benchmark/tpch/cli.py
+++ b/benchmark/tpch/cli.py
@@ -11,6 +11,7 @@ from util.workspace import (
     default_tables_dname,
     get_scale_factor_string,
     get_workload_name,
+    is_fully_resolved,
     link_result,
 )
 
@@ -94,11 +95,7 @@ def _clone_tpch_kit(dbgym_cfg: DBGymConfig) -> None:
 
 def _get_tpch_kit_dpath(dbgym_cfg: DBGymConfig) -> Path:
     tpch_kit_dpath = (dbgym_cfg.cur_symlinks_build_path() / "tpch-kit.link").resolve()
-    assert (
-        tpch_kit_dpath.exists()
-        and tpch_kit_dpath.is_absolute()
-        and not tpch_kit_dpath.is_symlink()
-    )
+    assert is_fully_resolved(tpch_kit_dpath)
     return tpch_kit_dpath
 
 
@@ -197,10 +194,8 @@ def _generate_tpch_workload(
                     symlink_data_dpath
                     / (_get_queries_dname(seed, scale_factor) + ".link")
                 ).resolve() / f"{qname}.sql"
-                assert (
-                    sql_fpath.exists()
-                    and not sql_fpath.is_symlink()
-                    and sql_fpath.is_absolute()
+                assert is_fully_resolved(
+                    sql_fpath
                 ), "We should only write existent real absolute paths to a file"
                 f.write(f"S{seed}-Q{qname},{sql_fpath}\n")
                 # TODO(WAN): add option to deep-copy the workload.

--- a/benchmark/tpch/load_info.py
+++ b/benchmark/tpch/load_info.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 from dbms.load_info_base_class import LoadInfoBaseClass
-from util.workspace import DBGymConfig, default_tables_dname
+from util.workspace import DBGymConfig, default_tables_dname, is_fully_resolved
 
 TPCH_SCHEMA_FNAME = "tpch_schema.sql"
 TPCH_CONSTRAINTS_FNAME = "tpch_constraints.sql"
@@ -48,10 +48,8 @@ class TpchLoadInfo(LoadInfoBaseClass):
             data_root_dpath / f"{default_tables_dname(scale_factor)}.link"
         )
         tables_dpath = tables_symlink_dpath.resolve()
-        assert (
-            tables_dpath.exists()
-            and tables_dpath.is_absolute()
-            and not tables_dpath.is_symlink()
+        assert is_fully_resolved(
+            tables_dpath
         ), f"tables_dpath ({tables_dpath}) should be an existent real absolute path. Make sure you have generated the TPC-H data"
         self._tables_and_fpaths = []
         for table in TpchLoadInfo.TABLES:

--- a/dbms/postgres/cli.py
+++ b/dbms/postgres/cli.py
@@ -108,7 +108,7 @@ def postgres_dbdata(
             dbgym_cfg.dbgym_workspace_path
         )
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
     dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
 

--- a/dbms/postgres/cli.py
+++ b/dbms/postgres/cli.py
@@ -35,9 +35,9 @@ from util.shell import subprocess_run
 from util.workspace import (
     WORKSPACE_PATH_PLACEHOLDER,
     DBGymConfig,
-    conv_inputpath_to_realabspath,
     default_dbdata_parent_dpath,
     default_pgbin_path,
+    fully_resolve_inputpath,
     get_dbdata_tgz_name,
     is_ssd,
     link_result,
@@ -108,8 +108,8 @@ def postgres_dbdata(
         )
 
     # Convert all input paths to absolute paths
-    pgbin_path = conv_inputpath_to_realabspath(dbgym_cfg, pgbin_path)
-    dbdata_parent_dpath = conv_inputpath_to_realabspath(dbgym_cfg, dbdata_parent_dpath)
+    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
+    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
 
     # Check assertions on args
     if intended_dbdata_hardware == "hdd":

--- a/dbms/postgres/cli.py
+++ b/dbms/postgres/cli.py
@@ -37,7 +37,7 @@ from util.workspace import (
     DBGymConfig,
     default_dbdata_parent_dpath,
     default_pgbin_path,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_dbdata_tgz_name,
     is_fully_resolved,
     is_ssd,
@@ -109,8 +109,8 @@ def postgres_dbdata(
         )
 
     # Fully resolve all input paths.
-    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
-    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
+    pgbin_path = fully_resolve_path(dbgym_cfg, pgbin_path)
+    dbdata_parent_dpath = fully_resolve_path(dbgym_cfg, dbdata_parent_dpath)
 
     # Check assertions on args
     if intended_dbdata_hardware == "hdd":

--- a/dbms/postgres/cli.py
+++ b/dbms/postgres/cli.py
@@ -39,6 +39,7 @@ from util.workspace import (
     default_pgbin_path,
     fully_resolve_inputpath,
     get_dbdata_tgz_name,
+    is_fully_resolved,
     is_ssd,
     link_result,
     open_and_save,
@@ -316,13 +317,10 @@ def _start_or_stop_postgres(
     dbgym_cfg: DBGymConfig, pgbin_path: Path, dbdata_dpath: Path, is_start: bool
 ) -> None:
     # They should be absolute paths and should exist
-    assert pgbin_path.is_absolute() and pgbin_path.exists()
-    assert dbdata_dpath.is_absolute() and dbdata_dpath.exists()
-    # The inputs may be symlinks so we need to resolve them first
-    pgbin_real_dpath = pgbin_path.resolve()
-    dbdata_dpath = dbdata_dpath.resolve()
+    assert is_fully_resolved(pgbin_path)
+    assert is_fully_resolved(dbdata_dpath)
     pgport = DEFAULT_POSTGRES_PORT
-    save_file(dbgym_cfg, pgbin_real_dpath / "pg_ctl")
+    save_file(dbgym_cfg, pgbin_path / "pg_ctl")
 
     if is_start:
         # We use subprocess.run() because subprocess_run() never returns when running "pg_ctl start".
@@ -330,12 +328,12 @@ def _start_or_stop_postgres(
         # On the other hand, subprocess.run() does return normally, like calling `./pg_ctl` on the command line would do.
         result = subprocess.run(
             f"./pg_ctl -D \"{dbdata_dpath}\" -o '-p {pgport}' start",
-            cwd=pgbin_real_dpath,
+            cwd=pgbin_path,
             shell=True,
         )
         result.check_returncode()
     else:
         subprocess_run(
             f"./pg_ctl -D \"{dbdata_dpath}\" -o '-p {pgport}' stop",
-            cwd=pgbin_real_dpath,
+            cwd=pgbin_path,
         )

--- a/env/integtest_tuning_agent.py
+++ b/env/integtest_tuning_agent.py
@@ -32,9 +32,9 @@ class PostgresConnTests(unittest.TestCase):
     @staticmethod
     def make_config(letter: str) -> DBMSConfigDelta:
         return DBMSConfigDelta(
-            IndexesDelta([letter]),
-            SysKnobsDelta({letter: letter}),
-            QueryKnobsDelta({letter: [letter]}),
+            indexes=IndexesDelta([letter]),
+            sysknobs=SysKnobsDelta({letter: letter}),
+            qknobs=QueryKnobsDelta({letter: [letter]}),
         )
 
     def test_get_step_delta(self) -> None:

--- a/env/integtest_tuning_agent.py
+++ b/env/integtest_tuning_agent.py
@@ -8,6 +8,7 @@ from env.tuning_agent import (
     QueryKnobsDelta,
     SysKnobsDelta,
     TuningAgent,
+    TuningAgentStepReader,
 )
 
 
@@ -47,10 +48,12 @@ class PostgresConnTests(unittest.TestCase):
         agent.config_to_return = PostgresConnTests.make_config("c")
         agent.step()
 
-        self.assertEqual(agent.get_step_delta(1), PostgresConnTests.make_config("b"))
-        self.assertEqual(agent.get_step_delta(0), PostgresConnTests.make_config("a"))
-        self.assertEqual(agent.get_step_delta(1), PostgresConnTests.make_config("b"))
-        self.assertEqual(agent.get_step_delta(2), PostgresConnTests.make_config("c"))
+        reader = TuningAgentStepReader(agent.dbms_cfg_deltas_dpath)
+
+        self.assertEqual(reader.get_step_delta(1), PostgresConnTests.make_config("b"))
+        self.assertEqual(reader.get_step_delta(0), PostgresConnTests.make_config("a"))
+        self.assertEqual(reader.get_step_delta(1), PostgresConnTests.make_config("b"))
+        self.assertEqual(reader.get_step_delta(2), PostgresConnTests.make_config("c"))
 
     def test_get_all_deltas(self) -> None:
         agent = MockTuningAgent(IntegtestWorkspace.get_dbgym_cfg())
@@ -62,8 +65,10 @@ class PostgresConnTests(unittest.TestCase):
         agent.config_to_return = PostgresConnTests.make_config("c")
         agent.step()
 
+        reader = TuningAgentStepReader(agent.dbms_cfg_deltas_dpath)
+
         self.assertEqual(
-            agent.get_all_deltas(),
+            reader.get_all_deltas(),
             [
                 PostgresConnTests.make_config("a"),
                 PostgresConnTests.make_config("b"),

--- a/env/integtest_tuning_agent.py
+++ b/env/integtest_tuning_agent.py
@@ -2,7 +2,13 @@ import unittest
 from typing import Any, Optional
 
 from env.integtest_util import IntegtestWorkspace
-from env.tuning_agent import DBMSConfigDelta, TuningAgent
+from env.tuning_agent import (
+    DBMSConfigDelta,
+    IndexesDelta,
+    QueryKnobsDelta,
+    SysKnobsDelta,
+    TuningAgent,
+)
 
 
 class MockTuningAgent(TuningAgent):
@@ -25,7 +31,11 @@ class PostgresConnTests(unittest.TestCase):
 
     @staticmethod
     def make_config(letter: str) -> DBMSConfigDelta:
-        return DBMSConfigDelta([letter], {letter: letter}, {letter: [letter]})
+        return DBMSConfigDelta(
+            IndexesDelta([letter]),
+            SysKnobsDelta({letter: letter}),
+            QueryKnobsDelta({letter: [letter]}),
+        )
 
     def test_get_step_delta(self) -> None:
         agent = MockTuningAgent(IntegtestWorkspace.get_dbgym_cfg())

--- a/env/tuning_agent.py
+++ b/env/tuning_agent.py
@@ -1,8 +1,13 @@
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import NewType
 
 from util.workspace import DBGymConfig
+
+IndexesDelta = NewType("IndexesDelta", list[str])
+SysKnobsDelta = NewType("SysKnobsDelta", dict[str, str])
+QueryKnobsDelta = NewType("QueryKnobsDelta", dict[str, list[str]])
 
 
 @dataclass
@@ -21,9 +26,9 @@ class DBMSConfigDelta:
     because knobs can be settings ("SET (enable_sort on)") or flags ("IndexOnlyScan(it)").
     """
 
-    indexes: list[str]
-    sysknobs: dict[str, str]
-    qknobs: dict[str, list[str]]
+    indexes: IndexesDelta
+    sysknobs: SysKnobsDelta
+    qknobs: QueryKnobsDelta
 
 
 class TuningAgent:

--- a/env/tuning_agent.py
+++ b/env/tuning_agent.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import NewType, TypedDict
 
-from util.workspace import DBGymConfig
+from util.workspace import DBGymConfig, is_fully_resolved
 
 # PostgresConn doesn't use these types because PostgresConn is used internally by tuning agents.
 # These types are only given as the outputs of tuning agents.
@@ -68,6 +68,7 @@ class TuningAgent:
 class TuningAgentStepReader:
     def __init__(self, dbms_cfg_deltas_dpath: Path) -> None:
         self.dbms_cfg_deltas_dpath = dbms_cfg_deltas_dpath
+        assert is_fully_resolved(self.dbms_cfg_deltas_dpath)
         num_steps = 0
         while get_step_delta_fpath(self.dbms_cfg_deltas_dpath, num_steps).exists():
             num_steps += 1

--- a/tune/protox/agent/hpo.py
+++ b/tune/protox/agent/hpo.py
@@ -294,7 +294,7 @@ def hpo(
     if seed is None:
         seed = random.randint(0, int(1e8))
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     embedder_path = fully_resolve_inputpath(dbgym_cfg, embedder_path)
     benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
     benchbase_config_path = fully_resolve_inputpath(dbgym_cfg, benchbase_config_path)

--- a/tune/protox/agent/hpo.py
+++ b/tune/protox/agent/hpo.py
@@ -43,7 +43,7 @@ from util.workspace import (
     default_pgbin_path,
     default_pristine_dbdata_snapshot_path,
     default_workload_path,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_default_workload_name_suffix,
     get_workload_name,
     is_ssd,
@@ -295,17 +295,17 @@ def hpo(
         seed = random.randint(0, int(1e8))
 
     # Fully resolve all input paths.
-    embedder_path = fully_resolve_inputpath(dbgym_cfg, embedder_path)
-    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
-    benchbase_config_path = fully_resolve_inputpath(dbgym_cfg, benchbase_config_path)
-    sysknobs_path = fully_resolve_inputpath(dbgym_cfg, sysknobs_path)
-    pristine_dbdata_snapshot_path = fully_resolve_inputpath(
+    embedder_path = fully_resolve_path(dbgym_cfg, embedder_path)
+    benchmark_config_path = fully_resolve_path(dbgym_cfg, benchmark_config_path)
+    benchbase_config_path = fully_resolve_path(dbgym_cfg, benchbase_config_path)
+    sysknobs_path = fully_resolve_path(dbgym_cfg, sysknobs_path)
+    pristine_dbdata_snapshot_path = fully_resolve_path(
         dbgym_cfg, pristine_dbdata_snapshot_path
     )
-    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
-    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
-    workload_path = fully_resolve_inputpath(dbgym_cfg, workload_path)
-    boot_config_fpath_during_hpo = fully_resolve_inputpath(
+    dbdata_parent_dpath = fully_resolve_path(dbgym_cfg, dbdata_parent_dpath)
+    pgbin_path = fully_resolve_path(dbgym_cfg, pgbin_path)
+    workload_path = fully_resolve_path(dbgym_cfg, workload_path)
+    boot_config_fpath_during_hpo = fully_resolve_path(
         dbgym_cfg, boot_config_fpath_during_hpo
     )
 

--- a/tune/protox/agent/hpo.py
+++ b/tune/protox/agent/hpo.py
@@ -35,7 +35,6 @@ from util.workspace import (
     WORKSPACE_PATH_PLACEHOLDER,
     DBGymConfig,
     TuningMode,
-    conv_inputpath_to_realabspath,
     default_benchbase_config_path,
     default_benchmark_config_path,
     default_dbdata_parent_dpath,
@@ -44,6 +43,7 @@ from util.workspace import (
     default_pgbin_path,
     default_pristine_dbdata_snapshot_path,
     default_workload_path,
+    fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
     is_ssd,
@@ -295,21 +295,17 @@ def hpo(
         seed = random.randint(0, int(1e8))
 
     # Convert all input paths to absolute paths
-    embedder_path = conv_inputpath_to_realabspath(dbgym_cfg, embedder_path)
-    benchmark_config_path = conv_inputpath_to_realabspath(
-        dbgym_cfg, benchmark_config_path
-    )
-    benchbase_config_path = conv_inputpath_to_realabspath(
-        dbgym_cfg, benchbase_config_path
-    )
-    sysknobs_path = conv_inputpath_to_realabspath(dbgym_cfg, sysknobs_path)
-    pristine_dbdata_snapshot_path = conv_inputpath_to_realabspath(
+    embedder_path = fully_resolve_inputpath(dbgym_cfg, embedder_path)
+    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
+    benchbase_config_path = fully_resolve_inputpath(dbgym_cfg, benchbase_config_path)
+    sysknobs_path = fully_resolve_inputpath(dbgym_cfg, sysknobs_path)
+    pristine_dbdata_snapshot_path = fully_resolve_inputpath(
         dbgym_cfg, pristine_dbdata_snapshot_path
     )
-    dbdata_parent_dpath = conv_inputpath_to_realabspath(dbgym_cfg, dbdata_parent_dpath)
-    pgbin_path = conv_inputpath_to_realabspath(dbgym_cfg, pgbin_path)
-    workload_path = conv_inputpath_to_realabspath(dbgym_cfg, workload_path)
-    boot_config_fpath_during_hpo = conv_inputpath_to_realabspath(
+    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
+    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
+    workload_path = fully_resolve_inputpath(dbgym_cfg, workload_path)
+    boot_config_fpath_during_hpo = fully_resolve_inputpath(
         dbgym_cfg, boot_config_fpath_during_hpo
     )
 

--- a/tune/protox/agent/replay.py
+++ b/tune/protox/agent/replay.py
@@ -33,7 +33,7 @@ from util.workspace import (
     TuningMode,
     default_replay_data_fname,
     default_tuning_steps_dpath,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_default_workload_name_suffix,
     get_workload_name,
     link_result,
@@ -152,7 +152,7 @@ def replay(
         )
 
     # Fully resolve all input paths.
-    tuning_steps_dpath = fully_resolve_inputpath(dbgym_cfg, tuning_steps_dpath)
+    tuning_steps_dpath = fully_resolve_path(dbgym_cfg, tuning_steps_dpath)
 
     # Group args together to reduce the # of parameters we pass into functions
     replay_args = ReplayArgs(

--- a/tune/protox/agent/replay.py
+++ b/tune/protox/agent/replay.py
@@ -31,9 +31,9 @@ from util.log import DBGYM_LOGGER_NAME, DBGYM_OUTPUT_LOGGER_NAME
 from util.workspace import (
     DBGymConfig,
     TuningMode,
-    conv_inputpath_to_realabspath,
     default_replay_data_fname,
     default_tuning_steps_dpath,
+    fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
     link_result,
@@ -152,7 +152,7 @@ def replay(
         )
 
     # Convert all input paths to absolute paths
-    tuning_steps_dpath = conv_inputpath_to_realabspath(dbgym_cfg, tuning_steps_dpath)
+    tuning_steps_dpath = fully_resolve_inputpath(dbgym_cfg, tuning_steps_dpath)
 
     # Group args together to reduce the # of parameters we pass into functions
     replay_args = ReplayArgs(

--- a/tune/protox/agent/replay.py
+++ b/tune/protox/agent/replay.py
@@ -151,7 +151,7 @@ def replay(
             boot_enabled_during_tune,
         )
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     tuning_steps_dpath = fully_resolve_inputpath(dbgym_cfg, tuning_steps_dpath)
 
     # Group args together to reduce the # of parameters we pass into functions

--- a/tune/protox/agent/tune.py
+++ b/tune/protox/agent/tune.py
@@ -17,9 +17,9 @@ from util.workspace import (
     WORKSPACE_PATH_PLACEHOLDER,
     DBGymConfig,
     TuningMode,
-    conv_inputpath_to_realabspath,
     default_hpoed_agent_params_path,
     default_tuning_steps_dname,
+    fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
     link_result,
@@ -87,10 +87,10 @@ def tune(
         )
 
     # Convert all input paths to absolute paths
-    hpoed_agent_params_path = conv_inputpath_to_realabspath(
+    hpoed_agent_params_path = fully_resolve_inputpath(
         dbgym_cfg, hpoed_agent_params_path
     )
-    boot_config_fpath_during_tune = conv_inputpath_to_realabspath(
+    boot_config_fpath_during_tune = fully_resolve_inputpath(
         dbgym_cfg, boot_config_fpath_during_tune
     )
 

--- a/tune/protox/agent/tune.py
+++ b/tune/protox/agent/tune.py
@@ -19,7 +19,7 @@ from util.workspace import (
     TuningMode,
     default_hpoed_agent_params_path,
     default_tuning_steps_dname,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_default_workload_name_suffix,
     get_workload_name,
     link_result,
@@ -87,10 +87,8 @@ def tune(
         )
 
     # Fully resolve all input paths.
-    hpoed_agent_params_path = fully_resolve_inputpath(
-        dbgym_cfg, hpoed_agent_params_path
-    )
-    boot_config_fpath_during_tune = fully_resolve_inputpath(
+    hpoed_agent_params_path = fully_resolve_path(dbgym_cfg, hpoed_agent_params_path)
+    boot_config_fpath_during_tune = fully_resolve_path(
         dbgym_cfg, boot_config_fpath_during_tune
     )
 

--- a/tune/protox/agent/tune.py
+++ b/tune/protox/agent/tune.py
@@ -86,7 +86,7 @@ def tune(
             dbgym_cfg.dbgym_workspace_path, benchmark_name, workload_name
         )
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     hpoed_agent_params_path = fully_resolve_inputpath(
         dbgym_cfg, hpoed_agent_params_path
     )

--- a/tune/protox/embedding/datagen.py
+++ b/tune/protox/embedding/datagen.py
@@ -226,7 +226,7 @@ def datagen(
     if seed is None:
         seed = random.randint(0, int(1e8))
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     workload_path = fully_resolve_inputpath(dbgym_cfg, workload_path)
     benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
     pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)

--- a/tune/protox/embedding/datagen.py
+++ b/tune/protox/embedding/datagen.py
@@ -47,6 +47,7 @@ from util.workspace import (
     fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
+    is_fully_resolved,
     is_ssd,
     link_result,
     open_and_save,
@@ -306,19 +307,17 @@ def untar_snapshot(
     dbgym_cfg: DBGymConfig, dbdata_snapshot_fpath: Path, dbdata_parent_dpath: Path
 ) -> Path:
     # It should be an absolute path and it should exist
-    assert (
-        dbdata_snapshot_fpath.is_absolute() and dbdata_snapshot_fpath.exists()
+    assert is_fully_resolved(
+        dbdata_snapshot_fpath
     ), f"untar_snapshot(): dbdata_snapshot_fpath ({dbdata_snapshot_fpath}) either doesn't exist or is not absolute"
-    # It may be a symlink so we need to resolve them first
-    dbdata_snapshot_real_fpath = dbdata_snapshot_fpath.resolve()
-    save_file(dbgym_cfg, dbdata_snapshot_real_fpath)
+    save_file(dbgym_cfg, dbdata_snapshot_fpath)
     dbdata_dpath = dbdata_parent_dpath / "dbdata"
     # Make the parent dir and the dbdata dir. Note how we require that dbdata_dpath does not exist while it's ok if the parent does.
     dbdata_parent_dpath.mkdir(parents=True, exist_ok=True)
     if dbdata_dpath.exists():
         shutil.rmtree(dbdata_dpath)
     dbdata_dpath.mkdir(parents=False, exist_ok=False)
-    subprocess_run(f"tar -xzf {dbdata_snapshot_real_fpath} -C {dbdata_dpath}")
+    subprocess_run(f"tar -xzf {dbdata_snapshot_fpath} -C {dbdata_dpath}")
     return dbdata_dpath
 
 

--- a/tune/protox/embedding/datagen.py
+++ b/tune/protox/embedding/datagen.py
@@ -38,13 +38,13 @@ from util.workspace import (
     WORKLOAD_NAME_PLACEHOLDER,
     WORKSPACE_PATH_PLACEHOLDER,
     DBGymConfig,
-    conv_inputpath_to_realabspath,
     default_benchmark_config_path,
     default_dbdata_parent_dpath,
     default_pgbin_path,
     default_pristine_dbdata_snapshot_path,
     default_traindata_fname,
     default_workload_path,
+    fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
     is_ssd,
@@ -226,15 +226,13 @@ def datagen(
         seed = random.randint(0, int(1e8))
 
     # Convert all input paths to absolute paths
-    workload_path = conv_inputpath_to_realabspath(dbgym_cfg, workload_path)
-    benchmark_config_path = conv_inputpath_to_realabspath(
-        dbgym_cfg, benchmark_config_path
-    )
-    pgbin_path = conv_inputpath_to_realabspath(dbgym_cfg, pgbin_path)
-    pristine_dbdata_snapshot_path = conv_inputpath_to_realabspath(
+    workload_path = fully_resolve_inputpath(dbgym_cfg, workload_path)
+    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
+    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
+    pristine_dbdata_snapshot_path = fully_resolve_inputpath(
         dbgym_cfg, pristine_dbdata_snapshot_path
     )
-    dbdata_parent_dpath = conv_inputpath_to_realabspath(dbgym_cfg, dbdata_parent_dpath)
+    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
 
     # Check assertions on args
     if intended_dbdata_hardware == "hdd":

--- a/tune/protox/embedding/datagen.py
+++ b/tune/protox/embedding/datagen.py
@@ -44,7 +44,7 @@ from util.workspace import (
     default_pristine_dbdata_snapshot_path,
     default_traindata_fname,
     default_workload_path,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_default_workload_name_suffix,
     get_workload_name,
     is_fully_resolved,
@@ -227,13 +227,13 @@ def datagen(
         seed = random.randint(0, int(1e8))
 
     # Fully resolve all input paths.
-    workload_path = fully_resolve_inputpath(dbgym_cfg, workload_path)
-    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
-    pgbin_path = fully_resolve_inputpath(dbgym_cfg, pgbin_path)
-    pristine_dbdata_snapshot_path = fully_resolve_inputpath(
+    workload_path = fully_resolve_path(dbgym_cfg, workload_path)
+    benchmark_config_path = fully_resolve_path(dbgym_cfg, benchmark_config_path)
+    pgbin_path = fully_resolve_path(dbgym_cfg, pgbin_path)
+    pristine_dbdata_snapshot_path = fully_resolve_path(
         dbgym_cfg, pristine_dbdata_snapshot_path
     )
-    dbdata_parent_dpath = fully_resolve_inputpath(dbgym_cfg, dbdata_parent_dpath)
+    dbdata_parent_dpath = fully_resolve_path(dbgym_cfg, dbdata_parent_dpath)
 
     # Check assertions on args
     if intended_dbdata_hardware == "hdd":
@@ -293,7 +293,9 @@ def datagen(
         generic_args.pristine_dbdata_snapshot_path,
         generic_args.dbdata_parent_dpath,
     )
-    pgbin_path = default_pgbin_path(dbgym_cfg.dbgym_workspace_path)
+    pgbin_path = fully_resolve_path(
+        dbgym_cfg, default_pgbin_path(dbgym_cfg.dbgym_workspace_path)
+    )
     start_postgres(dbgym_cfg, pgbin_path, dbdata_dpath)
     _gen_traindata_dpath(dbgym_cfg, generic_args, dir_gen_args)
     _combine_traindata_dpath_into_parquet(dbgym_cfg, generic_args, file_gen_args)

--- a/tune/protox/embedding/train.py
+++ b/tune/protox/embedding/train.py
@@ -211,7 +211,7 @@ def train(
     if seed is None:
         seed = random.randint(0, int(1e8))
 
-    # Convert all input paths to absolute paths
+    # Fully resolve all input paths.
     benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
     traindata_path = fully_resolve_inputpath(dbgym_cfg, traindata_path)
     hpo_space_path = fully_resolve_inputpath(dbgym_cfg, hpo_space_path)

--- a/tune/protox/embedding/train.py
+++ b/tune/protox/embedding/train.py
@@ -32,7 +32,7 @@ from util.workspace import (
     default_benchmark_config_path,
     default_traindata_path,
     default_workload_path,
-    fully_resolve_inputpath,
+    fully_resolve_path,
     get_default_workload_name_suffix,
     get_workload_name,
 )
@@ -212,16 +212,16 @@ def train(
         seed = random.randint(0, int(1e8))
 
     # Fully resolve all input paths.
-    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
-    traindata_path = fully_resolve_inputpath(dbgym_cfg, traindata_path)
-    hpo_space_path = fully_resolve_inputpath(dbgym_cfg, hpo_space_path)
+    benchmark_config_path = fully_resolve_path(dbgym_cfg, benchmark_config_path)
+    traindata_path = fully_resolve_path(dbgym_cfg, traindata_path)
+    hpo_space_path = fully_resolve_path(dbgym_cfg, hpo_space_path)
 
     # setup
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
 
-    workload_path = fully_resolve_inputpath(
+    workload_path = fully_resolve_path(
         dbgym_cfg,
         default_workload_path(
             dbgym_cfg.dbgym_workspace_path, benchmark_name, workload_name

--- a/tune/protox/embedding/train.py
+++ b/tune/protox/embedding/train.py
@@ -29,10 +29,10 @@ from util.workspace import (
     WORKLOAD_NAME_PLACEHOLDER,
     WORKSPACE_PATH_PLACEHOLDER,
     DBGymConfig,
-    conv_inputpath_to_realabspath,
     default_benchmark_config_path,
     default_traindata_path,
     default_workload_path,
+    fully_resolve_inputpath,
     get_default_workload_name_suffix,
     get_workload_name,
 )
@@ -212,18 +212,16 @@ def train(
         seed = random.randint(0, int(1e8))
 
     # Convert all input paths to absolute paths
-    benchmark_config_path = conv_inputpath_to_realabspath(
-        dbgym_cfg, benchmark_config_path
-    )
-    traindata_path = conv_inputpath_to_realabspath(dbgym_cfg, traindata_path)
-    hpo_space_path = conv_inputpath_to_realabspath(dbgym_cfg, hpo_space_path)
+    benchmark_config_path = fully_resolve_inputpath(dbgym_cfg, benchmark_config_path)
+    traindata_path = fully_resolve_inputpath(dbgym_cfg, traindata_path)
+    hpo_space_path = fully_resolve_inputpath(dbgym_cfg, hpo_space_path)
 
     # setup
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
 
-    workload_path = conv_inputpath_to_realabspath(
+    workload_path = fully_resolve_inputpath(
         dbgym_cfg,
         default_workload_path(
             dbgym_cfg.dbgym_workspace_path, benchmark_name, workload_name

--- a/tune/protox/env/workload.py
+++ b/tune/protox/env/workload.py
@@ -41,7 +41,7 @@ from tune.protox.env.util.workload_analysis import (
     extract_sqltypes,
 )
 from util.log import DBGYM_LOGGER_NAME
-from util.workspace import DBGymConfig, open_and_save
+from util.workspace import DBGymConfig, is_fully_resolved, open_and_save
 
 
 class Workload(object):
@@ -66,8 +66,7 @@ class Workload(object):
         query_spec: QuerySpec,
     ) -> None:
         assert all(
-            sql[1].exists() and not sql[1].is_symlink() and sql[1].is_absolute()
-            for sql in sqls
+            is_fully_resolved(sql[1]) for sql in sqls
         ), f"sqls ({sqls}) should only contain existent real absolute paths."
         do_tbl_include_subsets_prune = query_spec["tbl_include_subsets_prune"]
         self.order = []

--- a/util/workspace.py
+++ b/util/workspace.py
@@ -362,15 +362,18 @@ def make_standard_dbgym_cfg() -> DBGymConfig:
     return dbgym_cfg
 
 
-def fully_resolve_inputpath(
-    dbgym_cfg: DBGymConfig, inputpath: os.PathLike[str]
-) -> Path:
+def fully_resolve_path(dbgym_cfg: DBGymConfig, inputpath: os.PathLike[str]) -> Path:
     """
-    Convert any user inputted path to a real, absolute path.
-    For flexibility, we take in any os.PathLike. However, for consistency, we always output a Path object
+    Fully resolve any path to a real, absolute path.
+
+    For flexibility, we take in any os.PathLike. However, for consistency, we always output a Path object.
+
     Whenever a path is required, the user is allowed to enter relative paths, absolute paths, or paths starting with ~.
+
     Relative paths are relative to the base dbgym repo dir.
+
     It *does not* check whether the path exists, since the user might be wanting to create a new file/dir.
+
     Raises RuntimeError for errors.
     """
     # For simplicity, we only process Path objects.
@@ -498,7 +501,7 @@ def open_and_save(dbgym_cfg: DBGymConfig, open_fpath: Path, mode: str = "r") -> 
     Open a file and "save" it to [workspace]/task_runs/run_*/.
     It takes in a str | Path to match the interface of open().
     This file does not work if open_fpath is a symlink, to make its interface identical to that of open().
-        Make sure to resolve all symlinks with fully_resolve_inputpath().
+        Make sure to resolve all symlinks with fully_resolve_path().
     To avoid confusion, I'm enforcing this function to only work with absolute paths.
     See the comment of save_file() for what "saving" means
     If you are generating a "result" for the run, _do not_ use this. Just use the normal open().
@@ -647,7 +650,7 @@ def link_result(
     assert is_fully_resolved(
         result_fordpath
     ), f"result_fordpath ({result_fordpath}) should be a fully resolved path"
-    result_fordpath = fully_resolve_inputpath(dbgym_cfg, result_fordpath)
+    result_fordpath = fully_resolve_path(dbgym_cfg, result_fordpath)
     assert is_child_path(result_fordpath, dbgym_cfg.dbgym_this_run_path)
     assert not os.path.islink(result_fordpath)
 


### PR DESCRIPTION
**Summary**: standardized all asserts to use `is_fully_resolved()` and made `is_fully_resolved()` more robust.

**Details**:
* Fully resolved now means existent, no symlinks in ancestry, and absolute.
* Also factored `TuningAgentStepReader` out of `TuningAgent` to prepare for replay (this was the change that motivated this refactor).