### PR TITLE
./pipfreeze.sh ignoring gymlib

### DIFF
--- a/scripts/pipfreeze.sh
+++ b/scripts/pipfreeze.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-pip freeze >scripts/configs/requirements.txt
+# Ignore gymlib because we install it manually inside _build_conda_env.sh (not from requirements.txt).
+pip freeze | grep -v "^gymlib @" >scripts/configs/requirements.txt


### PR DESCRIPTION
**Summary**: pipfreeze.sh now automatically ignores `gymlib` when writing `requirements.txt`.